### PR TITLE
Log real IP address and fix textarea padding in Safari

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -25,6 +25,10 @@
     --textarea-border-dark: #454545;
 }
 
+* {
+    box-sizing: border-box;
+}
+
 body {
     color: var(--text-light);
     background-color: var(--bg-light);

--- a/serve.go
+++ b/serve.go
@@ -12,6 +12,7 @@ import (
 // Serve starts the app's web server
 func Serve() {
 	r := chi.NewRouter()
+	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger, middleware.CleanPath, middleware.StripSlashes)
 	r.NotFound(NotFound)
 


### PR DESCRIPTION
Log real IP address of the client when accessed through a reverse proxy